### PR TITLE
Changed hash to be safer with period (.) instead of underscore (_) replacement of plus (+)

### DIFF
--- a/dii.storage.tests/UtilityTests/Data/ValidateIdHashData.cs
+++ b/dii.storage.tests/UtilityTests/Data/ValidateIdHashData.cs
@@ -6,7 +6,7 @@ namespace dii.storage.tests.UtilityTests.Data
     {
         public ValidateIdHashData()
         {
-            Add("U_G0BFVe2Ag", true);
+            Add("U.G0BFVe2Ag", true);
             Add("U=G0BFVe2Ag", true);
             Add("Abcdefg", true);
             Add(null, false);

--- a/dii.storage.tests/UtilityTests/IdHashUtilityTests.cs
+++ b/dii.storage.tests/UtilityTests/IdHashUtilityTests.cs
@@ -68,7 +68,7 @@ namespace dii.storage.tests.UtilityTests
                     throw new ArgumentException("Testing unsupported type for IdHashUtility.ToIdHash().");
             }
 
-            Assert.Equal("gBNEpi_Y2Qg", id);
+            Assert.Equal("gBNEpi.Y2Qg", id);
         }
 
         [Theory, TestPriorityOrder(104), ClassData(typeof(ToIdHashData))]
@@ -96,10 +96,10 @@ namespace dii.storage.tests.UtilityTests
                     id = IdHashUtility.AsIdHash(ul);
                     break;
                 default:
-                    throw new ArgumentException("Testing unsupported type for IdHashUtility.ToIdHash().");
+                    throw new ArgumentException("Testing unsupported type for IdHashUtility.AsIdHash().");
             }
 
-            Assert.Equal("gBNEpi_Y2Qg", id);
+            Assert.Equal("gBNEpi.Y2Qg", id);
         }
 
         #region Teardown

--- a/dii.storage/Utilities/IdHashUtility.cs
+++ b/dii.storage/Utilities/IdHashUtility.cs
@@ -27,7 +27,7 @@ namespace dii.storage.Utilities
         {
             if (!string.IsNullOrWhiteSpace(idHash))
             {
-                var validator = new Regex(@"^[a-zA-Z0-9_=]+$");
+                var validator = new Regex(@"^[a-zA-Z0-9.=]+$");
 
                 if (validator.IsMatch(idHash))
                 {
@@ -108,7 +108,7 @@ namespace dii.storage.Utilities
 
         private static string GenerateHash(byte[] bytes)
         {
-            return Convert.ToBase64String(bytes, Base64FormattingOptions.None).TrimEnd('=').Replace("/", "=").Replace("+", "_");
+            return Convert.ToBase64String(bytes, Base64FormattingOptions.None).TrimEnd('=').Replace("/", "=").Replace("+", ".");
         }
     }
 }

--- a/dii.storage/dii.storage.csproj
+++ b/dii.storage/dii.storage.csproj
@@ -11,7 +11,7 @@
     <Authors>Andrew Beers &amp; Pat MacMannis</Authors>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageId>dii.storage</PackageId>
-    <Version>1.2.2</Version>
+    <Version>1.2.2.1</Version>
     <AssemblyName>dii.storage</AssemblyName>
     <RootNamespace>dii.storage</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Note: `dii.storage.cosmos` is not impacted by this change.