### PR TITLE
Adjusted the unit tests to allow both continual run and individual run with the optimizer.Get() method.

### DIFF
--- a/dii.storage.cosmos.tests/DiiCosmosContextTests/DoesDatabaseExistTests.cs
+++ b/dii.storage.cosmos.tests/DiiCosmosContextTests/DoesDatabaseExistTests.cs
@@ -12,8 +12,7 @@ namespace dii.storage.cosmos.tests.DiiCosmosContextTests
     [TestCaseOrderer(TestPriorityOrderer.FullName, TestPriorityOrderer.AssemblyName)]
     public class DoesDatabaseExistTests
     {
-        [Fact, TestPriorityOrder(100)]
-        public void DoesDatabaseExistAsync_Prep()
+        public DoesDatabaseExistTests()
         {
             var fakeCosmosDatabaseConfig = new FakeCosmosDatabaseConfig();
 
@@ -22,7 +21,7 @@ namespace dii.storage.cosmos.tests.DiiCosmosContextTests
             Assert.NotNull(context);
         }
 
-        [Fact, TestPriorityOrder(101)]
+        [Fact, TestPriorityOrder(100)]
         public async Task DoesDatabaseExistAsync_Success()
         {
             var context = DiiCosmosContext.Get();

--- a/dii.storage.cosmos.tests/DiiCosmosContextTests/InitTablesTests.cs
+++ b/dii.storage.cosmos.tests/DiiCosmosContextTests/InitTablesTests.cs
@@ -17,22 +17,23 @@ namespace dii.storage.cosmos.tests.DiiCosmosContextTests
     [TestCaseOrderer(TestPriorityOrderer.FullName, TestPriorityOrderer.AssemblyName)]
     public class InitTablesTests
     {
-        [Fact, TestPriorityOrder(100)]
-        public void InitTablesAsync_Prep()
+        public InitTablesTests()
         {
             var fakeCosmosDatabaseConfig = new FakeCosmosDatabaseConfig();
 
             var context = DiiCosmosContext.Init(fakeCosmosDatabaseConfig);
 
             Assert.NotNull(context);
-            Assert.Null(context.TableMappings);
 
-            _ = Optimizer.Init(typeof(FakeEntity));
+            if (context.TableMappings == null)
+            {
+                _ = Optimizer.Init(typeof(FakeEntity));
 
-            TestHelpers.AssertOptimizerIsInitialized();
+                TestHelpers.AssertOptimizerIsInitialized();
+            }
         }
 
-        [Theory, TestPriorityOrder(101), ClassData(typeof(ContextEmptyInitData))]
+        [Theory, TestPriorityOrder(100), ClassData(typeof(ContextEmptyInitData))]
         public async Task InitTablesAsync_NullTables(List<TableMetaData> tableMetaDatas)
         {
             var context = DiiCosmosContext.Get();
@@ -45,7 +46,7 @@ namespace dii.storage.cosmos.tests.DiiCosmosContextTests
             Assert.Equal(new ArgumentNullException("tableMetaDatas").Message, exception.Message);
         }
 
-        [Fact, TestPriorityOrder(102)]
+        [Fact, TestPriorityOrder(101)]
         public async Task InitTablesAsync_DbNotInitialized()
         {
             var context = DiiCosmosContext.Get();
@@ -62,7 +63,7 @@ namespace dii.storage.cosmos.tests.DiiCosmosContextTests
             Assert.Equal(new DiiNotInitializedException("Db").Message, exception.Message);
         }
 
-        [Fact, TestPriorityOrder(103)]
+        [Fact, TestPriorityOrder(102)]
         public async Task InitTablesAsync_Success()
         {
             var context = DiiCosmosContext.Get();

--- a/dii.storage.tests/AttributeTests/CompressTests.cs
+++ b/dii.storage.tests/AttributeTests/CompressTests.cs
@@ -12,12 +12,7 @@ namespace dii.storage.tests.AttributeTests
     [TestCaseOrderer(TestPriorityOrderer.FullName, TestPriorityOrderer.AssemblyName)]
     public class CompressTests
     {
-        //[Fact, TestPriorityOrder(100)]
-        //public void CompressTests_Prep()
-        //{
-        //}
-
-        [Theory, TestPriorityOrder(101), ClassData(typeof(CompressData))]
+        [Theory, TestPriorityOrder(100), ClassData(typeof(CompressData))]
         public void CompressTests_Success(int order)
         {
             var compressAttribute = new CompressAttribute(order);
@@ -26,7 +21,7 @@ namespace dii.storage.tests.AttributeTests
             Assert.Equal(order, compressAttribute.Order);
         }
 
-        [Theory, TestPriorityOrder(102), ClassData(typeof(CompressExceptionData))]
+        [Theory, TestPriorityOrder(101), ClassData(typeof(CompressExceptionData))]
         public void CompressTests_Exception(int order)
         {
             // Normally the property name would be derived from actual Attribute usage.
@@ -36,12 +31,5 @@ namespace dii.storage.tests.AttributeTests
             Assert.NotNull(exception);
             Assert.Equal($"The [Compress(order)] order on {propertyName} cannot be negative.", exception.Message);
         }
-
-        #region Teardown
-        //[Fact, TestPriorityOrder(int.MaxValue)]
-        //public void Teardown()
-        //{
-        //}
-        #endregion
     }
 }

--- a/dii.storage.tests/AttributeTests/EnableTimeToLiveAttributeTests.cs
+++ b/dii.storage.tests/AttributeTests/EnableTimeToLiveAttributeTests.cs
@@ -12,12 +12,7 @@ namespace dii.storage.tests.AttributeTests
     [TestCaseOrderer(TestPriorityOrderer.FullName, TestPriorityOrderer.AssemblyName)]
     public class EnableTimeToLiveAttributeTests
     {
-        //[Fact, TestPriorityOrder(100)]
-        //public void EnableTimeToLiveAttributeTests_Prep()
-        //{
-        //}
-
-        [Theory, TestPriorityOrder(101), ClassData(typeof(EnableTimeToLiveData))]
+        [Theory, TestPriorityOrder(100), ClassData(typeof(EnableTimeToLiveData))]
         public void EnableTimeToLiveAttributeTests_Success(int timeToLiveInSeconds)
         {
             var enableTimeToLiveAttribute = new EnableTimeToLiveAttribute(timeToLiveInSeconds);
@@ -26,7 +21,7 @@ namespace dii.storage.tests.AttributeTests
             Assert.Equal(timeToLiveInSeconds, enableTimeToLiveAttribute.TimeToLiveInSeconds);
         }
 
-        [Theory, TestPriorityOrder(102), ClassData(typeof(EnableTimeToLiveExceptionData))]
+        [Theory, TestPriorityOrder(101), ClassData(typeof(EnableTimeToLiveExceptionData))]
         public void EnableTimeToLiveAttributeTests_Exception(int timeToLiveInSeconds)
         {
             var exception = Assert.Throws<ArgumentOutOfRangeException>(() => { new EnableTimeToLiveAttribute(timeToLiveInSeconds); });
@@ -34,12 +29,5 @@ namespace dii.storage.tests.AttributeTests
             Assert.NotNull(exception);
             Assert.Equal("The time to live in seconds must be either a nonzero positive integer or '-1'. (Parameter 'timeToLiveInSeconds')", exception.Message);
         }
-
-        #region Teardown
-        //[Fact, TestPriorityOrder(int.MaxValue)]
-        //public void Teardown()
-        //{
-        //}
-        #endregion
     }
 }

--- a/dii.storage.tests/AttributeTests/IdTests.cs
+++ b/dii.storage.tests/AttributeTests/IdTests.cs
@@ -12,27 +12,17 @@ namespace dii.storage.tests.AttributeTests
     [TestCaseOrderer(TestPriorityOrderer.FullName, TestPriorityOrderer.AssemblyName)]
     public class IdTests
     {
-        [Fact, TestPriorityOrder(100)]
-        public void Id_Prep()
+        public IdTests()
         {
             _ = Optimizer.Init(typeof(MultipleIdEntity), typeof(FirstIdSeparatorWinsEntity));
 
             TestHelpers.AssertOptimizerIsInitialized();
         }
 
-        [Theory, TestPriorityOrder(101), ClassData(typeof(MultipleIdEntityData))]
+        [Theory, TestPriorityOrder(100), ClassData(typeof(MultipleIdEntityData))]
         public void Id_Success(MultipleIdEntity multipleIdEntity, string expected)
         {
-            Optimizer optimizer;
-            try
-            {
-                optimizer = Optimizer.Get();
-            }
-            catch
-            {
-                Id_Prep();
-                optimizer = Optimizer.Get();
-            }
+            var optimizer = Optimizer.Get();
 
             var entity = (dynamic)optimizer.ToEntity(multipleIdEntity);
 
@@ -43,19 +33,10 @@ namespace dii.storage.tests.AttributeTests
             Assert.Equal(expected, id);
         }
 
-        [Theory, TestPriorityOrder(102), ClassData(typeof(FirstIdSeparatorWinsEntityData))]
+        [Theory, TestPriorityOrder(101), ClassData(typeof(FirstIdSeparatorWinsEntityData))]
         public void Id_FirstSeparatorWins(FirstIdSeparatorWinsEntity firstIdSeparatorWinsEntity, string expected)
         {
-            Optimizer optimizer;
-            try
-            {
-                optimizer = Optimizer.Get();
-            }
-            catch
-            {
-                Id_Prep();
-                optimizer = Optimizer.Get();
-            }
+            var optimizer = Optimizer.Get();
 
             var entity = (dynamic)optimizer.ToEntity(firstIdSeparatorWinsEntity);
 

--- a/dii.storage.tests/AttributeTests/PartitionKeyTests.cs
+++ b/dii.storage.tests/AttributeTests/PartitionKeyTests.cs
@@ -12,15 +12,14 @@ namespace dii.storage.tests.AttributeTests
     [TestCaseOrderer(TestPriorityOrderer.FullName, TestPriorityOrderer.AssemblyName)]
     public class PartitionKeyTests
     {
-        [Fact, TestPriorityOrder(100)]
-        public void PartitionKey_Prep()
+        public PartitionKeyTests()
         {
             _ = Optimizer.Init(typeof(MultiplePartitionKeyEntity), typeof(FirstPartitionKeySeparatorWinsEntity));
 
             TestHelpers.AssertOptimizerIsInitialized();
         }
 
-        [Theory, TestPriorityOrder(101), ClassData(typeof(MultiplePKEntityData))]
+        [Theory, TestPriorityOrder(100), ClassData(typeof(MultiplePKEntityData))]
         public void PartitionKey_Success(MultiplePartitionKeyEntity multiplePartitionKeyEntity, string expected)
         {
             var optimizer = Optimizer.Get();
@@ -34,7 +33,7 @@ namespace dii.storage.tests.AttributeTests
             Assert.Equal(expected, pk);
         }
 
-        [Theory, TestPriorityOrder(102), ClassData(typeof(FirstPartitionKeySeparatorWinsEntityData))]
+        [Theory, TestPriorityOrder(101), ClassData(typeof(FirstPartitionKeySeparatorWinsEntityData))]
         public void PartitionKey_FirstSeparatorWins(FirstPartitionKeySeparatorWinsEntity firstPartitionKeySeparatorWinsEntity, string expected)
         {
             var optimizer = Optimizer.Get();

--- a/dii.storage.tests/AttributeTests/SearchableTests.cs
+++ b/dii.storage.tests/AttributeTests/SearchableTests.cs
@@ -12,12 +12,7 @@ namespace dii.storage.tests.AttributeTests
     [TestCaseOrderer(TestPriorityOrderer.FullName, TestPriorityOrderer.AssemblyName)]
     public class SearchableTests
     {
-        //[Fact, TestPriorityOrder(100)]
-        //public void SearchableTests_Prep()
-        //{
-        //}
-
-        [Theory, TestPriorityOrder(101), ClassData(typeof(SearchableData))]
+        [Theory, TestPriorityOrder(100), ClassData(typeof(SearchableData))]
         public void SearchableTests_Success(string abbreviation)
         {
             var searchableAttribute = new SearchableAttribute(abbreviation);
@@ -26,7 +21,7 @@ namespace dii.storage.tests.AttributeTests
             Assert.Equal(abbreviation, searchableAttribute.Abbreviation);
         }
 
-        [Theory, TestPriorityOrder(102), ClassData(typeof(SearchableExceptionData))]
+        [Theory, TestPriorityOrder(101), ClassData(typeof(SearchableExceptionData))]
         public void SearchableTests_Exception(string abbreviation)
         {
             // Normally the property name would be derived from actual Attribute usage.
@@ -36,12 +31,5 @@ namespace dii.storage.tests.AttributeTests
             Assert.NotNull(exception);
             Assert.Equal($"The [Searchable(key)] key on {propertyName} cannot be null, empty or whitespace.", exception.Message);
         }
-
-        #region Teardown
-        //[Fact, TestPriorityOrder(int.MaxValue)]
-        //public void Teardown()
-        //{
-        //}
-        #endregion
     }
 }

--- a/dii.storage.tests/AttributeTests/StorageNameTests.cs
+++ b/dii.storage.tests/AttributeTests/StorageNameTests.cs
@@ -10,12 +10,7 @@ namespace dii.storage.tests.AttributeTests
     [TestCaseOrderer(TestPriorityOrderer.FullName, TestPriorityOrderer.AssemblyName)]
     public class StorageNameTests
     {
-        //[Fact, TestPriorityOrder(100)]
-        //public void StorageNameTests_Prep()
-        //{
-        //}
-
-        [Fact, TestPriorityOrder(101)]
+        [Fact, TestPriorityOrder(100)]
         public void StorageNameTests_Success()
         {
             var storageNameAttribute = new StorageNameAttribute("Test-Entity-Name");
@@ -23,12 +18,5 @@ namespace dii.storage.tests.AttributeTests
             Assert.NotNull(storageNameAttribute);
             Assert.Equal("Test-Entity-Name", storageNameAttribute.Name);
         }
-
-        #region Teardown
-        //[Fact, TestPriorityOrder(int.MaxValue)]
-        //public void Teardown()
-        //{
-        //}
-        #endregion
     }
 }

--- a/dii.storage.tests/OptimizerTests/ConfigureTypesTests.cs
+++ b/dii.storage.tests/OptimizerTests/ConfigureTypesTests.cs
@@ -14,27 +14,17 @@ namespace dii.storage.tests.OptimizerTests
     [TestCaseOrderer(TestPriorityOrderer.FullName, TestPriorityOrderer.AssemblyName)]
     public class ConfigureTypesTests
     {
-        [Fact, TestPriorityOrder(100)]
-        public void ConfigureTypes_Prep()
+        public ConfigureTypesTests()
         {
             _ = Optimizer.Init(typeof(FakeEntity));
 
             TestHelpers.AssertOptimizerIsInitialized();
         }
 
-        [Theory, TestPriorityOrder(101), ClassData(typeof(ConfigureTypesNoOpData))]
+        [Theory, TestPriorityOrder(100), ClassData(typeof(ConfigureTypesNoOpData))]
         public void ConfigureTypes_NoOp(Type[] type)
         {
-            Optimizer optimizer;
-            try
-            {
-                optimizer = Optimizer.Get();
-            }
-            catch
-            {
-                ConfigureTypes_Prep();
-                optimizer = Optimizer.Get();
-            }
+            var optimizer = Optimizer.Get();
 
             Assert.Single(optimizer.Tables);
 
@@ -54,19 +44,10 @@ namespace dii.storage.tests.OptimizerTests
             Assert.Equal(tableMappingsInitialized[typeof(FakeEntity)].ClassName, optimizer.TableMappings[typeof(FakeEntity)].ClassName);
         }
 
-        [Theory, TestPriorityOrder(102), ClassData(typeof(ConfigureTypesInvalidSearchableKeyExceptionData))]
+        [Theory, TestPriorityOrder(101), ClassData(typeof(ConfigureTypesInvalidSearchableKeyExceptionData))]
         public void ConfigureTypes_AddTypeWithInvalidSearchableKey(Type type, string key, string propertyName, string typeName)
         {
-            Optimizer optimizer;
-            try
-            {
-                optimizer = Optimizer.Get();
-            }
-            catch
-            {
-                ConfigureTypes_Prep();
-                optimizer = Optimizer.Get();
-            }
+            var optimizer = Optimizer.Get();
 
             Assert.Single(optimizer.Tables);
 
@@ -89,19 +70,10 @@ namespace dii.storage.tests.OptimizerTests
             Assert.Equal(tableMappingsInitialized[typeof(FakeEntity)].ClassName, optimizer.TableMappings[typeof(FakeEntity)].ClassName);
         }
 
-        [Theory, TestPriorityOrder(103), ClassData(typeof(ConfigureTypesInvalidPartitionKeyOrderExceptionData))]
+        [Theory, TestPriorityOrder(102), ClassData(typeof(ConfigureTypesInvalidPartitionKeyOrderExceptionData))]
         public void ConfigureTypes_AddTypeWithInvalidPartitionKeyOrder(Type type, string propertyName, string duplicatePropertyName, int order)
         {
-            Optimizer optimizer;
-            try
-            {
-                optimizer = Optimizer.Get();
-            }
-            catch
-            {
-                ConfigureTypes_Prep();
-                optimizer = Optimizer.Get();
-            }
+            var optimizer = Optimizer.Get();
 
             Assert.Single(optimizer.Tables);
 
@@ -124,19 +96,10 @@ namespace dii.storage.tests.OptimizerTests
             Assert.Equal(tableMappingsInitialized[typeof(FakeEntity)].ClassName, optimizer.TableMappings[typeof(FakeEntity)].ClassName);
         }
 
-        [Theory, TestPriorityOrder(104), ClassData(typeof(ConfigureTypesInvalidIdOrderExceptionData))]
+        [Theory, TestPriorityOrder(103), ClassData(typeof(ConfigureTypesInvalidIdOrderExceptionData))]
         public void ConfigureTypes_AddTypeWithInvalidIdOrder(Type type, string propertyName, string duplicatePropertyName, int order)
         {
-            Optimizer optimizer;
-            try
-            {
-                optimizer = Optimizer.Get();
-            }
-            catch
-            {
-                ConfigureTypes_Prep();
-                optimizer = Optimizer.Get();
-            }
+            var optimizer = Optimizer.Get();
 
             Assert.Single(optimizer.Tables);
 
@@ -159,19 +122,10 @@ namespace dii.storage.tests.OptimizerTests
             Assert.Equal(tableMappingsInitialized[typeof(FakeEntity)].ClassName, optimizer.TableMappings[typeof(FakeEntity)].ClassName);
         }
 
-        [Fact, TestPriorityOrder(105)]
+        [Fact, TestPriorityOrder(104)]
         public void ConfigureTypes_AddNewType()
         {
-            Optimizer optimizer;
-            try
-            {
-                optimizer = Optimizer.Get();
-            }
-            catch
-            {
-                ConfigureTypes_Prep();
-                optimizer = Optimizer.Get();
-            }
+            var optimizer = Optimizer.Get();
 
             Assert.Single(optimizer.Tables);
 
@@ -194,19 +148,10 @@ namespace dii.storage.tests.OptimizerTests
             Assert.Equal(nameof(FakeEntityTwo), optimizer.TableMappings[typeof(FakeEntityTwo)].ClassName);
         }
 
-        [Fact, TestPriorityOrder(106)]
+        [Fact, TestPriorityOrder(105)]
         public void ConfigureTypes_AddNewTypeWithSameIdAndPKProperty()
         {
-            Optimizer optimizer;
-            try
-            {
-                optimizer = Optimizer.Get();
-            }
-            catch
-            {
-                ConfigureTypes_Prep();
-                optimizer = Optimizer.Get();
-            }
+            var optimizer = Optimizer.Get();
 
             Assert.Equal(2, optimizer.Tables.Count);
 

--- a/dii.storage.tests/OptimizerTests/FromEntityTests.cs
+++ b/dii.storage.tests/OptimizerTests/FromEntityTests.cs
@@ -14,27 +14,17 @@ namespace dii.storage.tests.OptimizerTests
     [TestCaseOrderer(TestPriorityOrderer.FullName, TestPriorityOrderer.AssemblyName)]
     public class FromEntityTests
     {
-        [Fact, TestPriorityOrder(100)]
-        public void FromEntity_Prep()
+        public FromEntityTests()
         {
             _ = Optimizer.Init(typeof(FakeEntityTwo), typeof(FakeEntityFive));
 
             TestHelpers.AssertOptimizerIsInitialized();
         }
 
-        [Fact, TestPriorityOrder(101)]
+        [Fact, TestPriorityOrder(100)]
         public void FromEntity_Success()
         {
-            Optimizer optimizer;
-            try
-            {
-                optimizer = Optimizer.Get();
-            }
-            catch
-            {
-                FromEntity_Prep();
-                optimizer = Optimizer.Get();
-            }
+            var optimizer = Optimizer.Get();
 
             var fakeEntityTwo = new FakeEntityTwo
             {
@@ -55,19 +45,10 @@ namespace dii.storage.tests.OptimizerTests
             Assert.Equal(fakeEntityTwo.CompressedStringValue, unpackedEntity.CompressedStringValue);
         }
 
-        [Fact, TestPriorityOrder(102)]
+        [Fact, TestPriorityOrder(101)]
         public void FromEntity_SuccessWithSameIdAndPKProperty()
         {
-            Optimizer optimizer;
-            try
-            {
-                optimizer = Optimizer.Get();
-            }
-            catch
-            {
-                FromEntity_Prep();
-                optimizer = Optimizer.Get();
-            }
+            var optimizer = Optimizer.Get();
 
             var fakeEntityFive = new FakeEntityFive
             {
@@ -88,38 +69,20 @@ namespace dii.storage.tests.OptimizerTests
             Assert.Equal(fakeEntityFive.CompressedStringValue, unpackedEntity.CompressedStringValue);
         }
 
-        [Theory, TestPriorityOrder(103), ClassData(typeof(FromEntityReturnDefaultData))]
+        [Theory, TestPriorityOrder(102), ClassData(typeof(FromEntityReturnDefaultData))]
         public void FromEntity_ReturnDefault(object entity)
         {
-            Optimizer optimizer;
-            try
-            {
-                optimizer = Optimizer.Get();
-            }
-            catch
-            {
-                FromEntity_Prep();
-                optimizer = Optimizer.Get();
-            }
+            var optimizer = Optimizer.Get();
 
             var unpackedEntity = optimizer.FromEntity<InvalidSearchableKeyEntity>(entity);
 
             Assert.Equal(default, unpackedEntity);
         }
 
-        [Fact, TestPriorityOrder(104)]
+        [Fact, TestPriorityOrder(103)]
         public void FromEntity_JsonSuccess()
         {
-            Optimizer optimizer;
-            try
-            {
-                optimizer = Optimizer.Get();
-            }
-            catch
-            {
-                FromEntity_Prep();
-                optimizer = Optimizer.Get();
-            }
+            var optimizer = Optimizer.Get();
 
             var id = Guid.NewGuid().ToString();
             var fakeEntityTwoJson = $@"{{
@@ -144,19 +107,10 @@ namespace dii.storage.tests.OptimizerTests
             Assert.Equal("\"00000000-0000-0000-79bf-5e755a3201d8\"", unpackedEntity.DataVersion);
         }
 
-        [Fact, TestPriorityOrder(105)]
+        [Fact, TestPriorityOrder(104)]
         public void FromEntity_JsonSuccessWithSameIdAndPKProperty()
         {
-            Optimizer optimizer;
-            try
-            {
-                optimizer = Optimizer.Get();
-            }
-            catch
-            {
-                FromEntity_Prep();
-                optimizer = Optimizer.Get();
-            }
+            var optimizer = Optimizer.Get();
 
             var id = Guid.NewGuid().ToString();
             var fakeEntityFiveJson = $@"{{
@@ -180,19 +134,10 @@ namespace dii.storage.tests.OptimizerTests
             Assert.Equal("\"00000000-0000-0000-79bf-5e755a3201d8\"", unpackedEntity.DataVersion);
         }
 
-        [Fact, TestPriorityOrder(106)]
+        [Fact, TestPriorityOrder(105)]
         public void FromEntity_JsonEmpty()
         {
-            Optimizer optimizer;
-            try
-            {
-                optimizer = Optimizer.Get();
-            }
-            catch
-            {
-                FromEntity_Prep();
-                optimizer = Optimizer.Get();
-            }
+            var optimizer = Optimizer.Get();
 
             var fakeEntityTwoJson = "{}";
 

--- a/dii.storage.tests/OptimizerTests/GetIdTests.cs
+++ b/dii.storage.tests/OptimizerTests/GetIdTests.cs
@@ -12,15 +12,14 @@ namespace dii.storage.tests.OptimizerTests
     [TestCaseOrderer(TestPriorityOrderer.FullName, TestPriorityOrderer.AssemblyName)]
     public class GetIdTests
     {
-        [Fact, TestPriorityOrder(100)]
-        public void GetId_Prep()
+        public GetIdTests()
         {
             _ = Optimizer.Init(typeof(FakeEntity));
 
             TestHelpers.AssertOptimizerIsInitialized();
         }
 
-        [Fact, TestPriorityOrder(101)]
+        [Fact, TestPriorityOrder(100)]
         public void GetId_Success()
         {
             var optimizer = Optimizer.Get();
@@ -36,7 +35,7 @@ namespace dii.storage.tests.OptimizerTests
             Assert.Equal(fakeEntity.Id, entity);
         }
 
-        [Fact, TestPriorityOrder(102)]
+        [Fact, TestPriorityOrder(101)]
         public void GetId_TypeNotFound()
         {
             var optimizer = Optimizer.Get();
@@ -52,7 +51,7 @@ namespace dii.storage.tests.OptimizerTests
             Assert.Equal(default, unpackedEntity);
         }
 
-        [Fact, TestPriorityOrder(103)]
+        [Fact, TestPriorityOrder(102)]
         public void GetId_Null()
         {
             var optimizer = Optimizer.Get();

--- a/dii.storage.tests/OptimizerTests/GetPartitionKeyTests.cs
+++ b/dii.storage.tests/OptimizerTests/GetPartitionKeyTests.cs
@@ -12,8 +12,7 @@ namespace dii.storage.tests.OptimizerTests
     [TestCaseOrderer(TestPriorityOrderer.FullName, TestPriorityOrderer.AssemblyName)]
     public class GetPartitionKeyTests
     {
-        [Fact, TestPriorityOrder(100)]
-        public void GetPartitionKey_Prep()
+        public GetPartitionKeyTests()
         {
             _ = Optimizer.Init(typeof(FakeEntity));
 
@@ -21,7 +20,7 @@ namespace dii.storage.tests.OptimizerTests
         }
 
         #region GetPartitionKey As Type
-        [Fact, TestPriorityOrder(101)]
+        [Fact, TestPriorityOrder(100)]
         public void GetPartitionKey_AsType_Success()
         {
             var optimizer = Optimizer.Get();
@@ -37,7 +36,7 @@ namespace dii.storage.tests.OptimizerTests
             Assert.Equal(new Guid(fakeEntity.FakeEntityId), entity);
         }
 
-        [Fact, TestPriorityOrder(102)]
+        [Fact, TestPriorityOrder(101)]
         public void GetPartitionKey_AsType_TypeNotFound()
         {
             var optimizer = Optimizer.Get();
@@ -53,7 +52,7 @@ namespace dii.storage.tests.OptimizerTests
             Assert.Equal(default, unpackedEntity);
         }
 
-        [Fact, TestPriorityOrder(103)]
+        [Fact, TestPriorityOrder(102)]
         public void GetPartitionKey_AsType_Null()
         {
             var optimizer = Optimizer.Get();

--- a/dii.storage.tests/OptimizerTests/GetPartitionKeyTypeTests.cs
+++ b/dii.storage.tests/OptimizerTests/GetPartitionKeyTypeTests.cs
@@ -12,15 +12,14 @@ namespace dii.storage.tests.OptimizerTests
     [TestCaseOrderer(TestPriorityOrderer.FullName, TestPriorityOrderer.AssemblyName)]
     public class GetPartitionKeyTypeTests
     {
-        [Fact, TestPriorityOrder(100)]
-        public void GetPartitionKeyType_Prep()
+        public GetPartitionKeyTypeTests()
         {
             _ = Optimizer.Init(typeof(FakeEntity));
 
             TestHelpers.AssertOptimizerIsInitialized();
         }
 
-        [Fact, TestPriorityOrder(101)]
+        [Fact, TestPriorityOrder(100)]
         public void GetPartitionKeyType_Success()
         {
             var optimizer = Optimizer.Get();
@@ -30,7 +29,7 @@ namespace dii.storage.tests.OptimizerTests
             Assert.Equal(typeof(Guid), type);
         }
 
-        [Fact, TestPriorityOrder(102)]
+        [Fact, TestPriorityOrder(101)]
         public void GetPartitionKeyType_NotFound()
         {
             var optimizer = Optimizer.Get();

--- a/dii.storage.tests/OptimizerTests/GetTests.cs
+++ b/dii.storage.tests/OptimizerTests/GetTests.cs
@@ -22,16 +22,12 @@ namespace dii.storage.tests.OptimizerTests
         }
 
         [Fact, TestPriorityOrder(101)]
-        public void Get_Prep()
+        public void Get_Success()
         {
             _ = Optimizer.Init(typeof(FakeEntity));
 
             TestHelpers.AssertOptimizerIsInitialized();
-        }
 
-        [Fact, TestPriorityOrder(102)]
-        public void Get_Success()
-        {
             var optimizer = Optimizer.Get();
 
             Assert.NotNull(optimizer);

--- a/dii.storage.tests/OptimizerTests/InitTests.cs
+++ b/dii.storage.tests/OptimizerTests/InitTests.cs
@@ -87,12 +87,5 @@ namespace dii.storage.tests.OptimizerTests
             Assert.NotNull(exception);
             Assert.Equal(new DiiInvalidNestingException(nameof(InvalidSelfReferenceEntity)).Message, exception.Message);
         }
-
-        #region Teardown
-        //[Fact, TestPriorityOrder(int.MaxValue)]
-        //public void Teardown()
-        //{
-        //}
-        #endregion
     }
 }

--- a/dii.storage.tests/OptimizerTests/IsKnownConcreteTypeTests.cs
+++ b/dii.storage.tests/OptimizerTests/IsKnownConcreteTypeTests.cs
@@ -12,15 +12,14 @@ namespace dii.storage.tests.OptimizerTests
     [TestCaseOrderer(TestPriorityOrderer.FullName, TestPriorityOrderer.AssemblyName)]
     public class IsKnownConcreteTypeTests
     {
-        [Fact, TestPriorityOrder(100)]
-        public void IsKnownConcreteType_Prep()
+        public IsKnownConcreteTypeTests()
         {
             _ = Optimizer.Init(typeof(FakeEntity));
 
             TestHelpers.AssertOptimizerIsInitialized();
         }
 
-        [Fact, TestPriorityOrder(101)]
+        [Fact, TestPriorityOrder(100)]
         public void IsKnownConcreteType_True()
         {
             var optimizer = Optimizer.Get();
@@ -28,7 +27,7 @@ namespace dii.storage.tests.OptimizerTests
             Assert.True(optimizer.IsKnownConcreteType(typeof(FakeEntity)));
         }
 
-        [Fact, TestPriorityOrder(102)]
+        [Fact, TestPriorityOrder(101)]
         public void IsKnownConcreteType_False()
         {
             var optimizer = Optimizer.Get();
@@ -36,7 +35,7 @@ namespace dii.storage.tests.OptimizerTests
             Assert.False(optimizer.IsKnownConcreteType(typeof(InvalidSearchableKeyEntity)));
         }
 
-        [Fact, TestPriorityOrder(103)]
+        [Fact, TestPriorityOrder(102)]
         public void IsKnownConcreteType_Null()
         {
             var optimizer = Optimizer.Get();

--- a/dii.storage.tests/OptimizerTests/IsKnownEmitTypeTests.cs
+++ b/dii.storage.tests/OptimizerTests/IsKnownEmitTypeTests.cs
@@ -12,15 +12,14 @@ namespace dii.storage.tests.OptimizerTests
     [TestCaseOrderer(TestPriorityOrderer.FullName, TestPriorityOrderer.AssemblyName)]
     public class IsKnownEmitTypeTests
     {
-        [Fact, TestPriorityOrder(100)]
-        public void IsKnownEmitType_Prep()
+        public IsKnownEmitTypeTests()
         {
             _ = Optimizer.Init(typeof(FakeEntity));
 
             TestHelpers.AssertOptimizerIsInitialized();
         }
 
-        [Fact, TestPriorityOrder(101)]
+        [Fact, TestPriorityOrder(100)]
         public void IsKnownEmitType_True()
         {
             var optimizer = Optimizer.Get();
@@ -31,7 +30,7 @@ namespace dii.storage.tests.OptimizerTests
             Assert.True(optimizer.IsKnownEmitType(storageType));
         }
 
-        [Fact, TestPriorityOrder(102)]
+        [Fact, TestPriorityOrder(101)]
         public void IsKnownEmitType_False()
         {
             var optimizer = Optimizer.Get();
@@ -39,7 +38,7 @@ namespace dii.storage.tests.OptimizerTests
             Assert.False(optimizer.IsKnownEmitType(typeof(InvalidSearchableKeyEntity)));
         }
 
-        [Fact, TestPriorityOrder(103)]
+        [Fact, TestPriorityOrder(102)]
         public void IsKnownEmitType_Null()
         {
             var optimizer = Optimizer.Get();

--- a/dii.storage.tests/OptimizerTests/PackageToJsonTests.cs
+++ b/dii.storage.tests/OptimizerTests/PackageToJsonTests.cs
@@ -1,5 +1,4 @@
-﻿using dii.storage.Exceptions;
-using dii.storage.tests.Attributes;
+﻿using dii.storage.tests.Attributes;
 using dii.storage.tests.Models;
 using dii.storage.tests.Orderer;
 using dii.storage.tests.Utilities;
@@ -14,27 +13,17 @@ namespace dii.storage.tests.OptimizerTests
     [TestCaseOrderer(TestPriorityOrderer.FullName, TestPriorityOrderer.AssemblyName)]
     public class PackageToJsonTests
     {
-        [Fact, TestPriorityOrder(100)]
-        public void PackageToJson_Prep()
+        public PackageToJsonTests()
         {
             _ = Optimizer.Init(typeof(FakeEntityTwo));
 
             TestHelpers.AssertOptimizerIsInitialized();
         }
 
-        [Fact, TestPriorityOrder(101)]
+        [Fact, TestPriorityOrder(100)]
         public void PackageToJson_Success()
         {
-            Optimizer optimizer;
-            try
-            {
-                optimizer = Optimizer.Get();
-            }
-            catch
-            {
-                PackageToJson_Prep();
-                optimizer = Optimizer.Get();
-            }
+            var optimizer = Optimizer.Get();
 
             var fakeEntityTwo = new FakeEntityTwo
             {
@@ -50,20 +39,10 @@ namespace dii.storage.tests.OptimizerTests
             Assert.Equal(expectedEntity, entity);
         }
 
-        [Fact, TestPriorityOrder(102)]
+        [Fact, TestPriorityOrder(101)]
         public void PackageToJson_CollectionComplex_Success()
         {
-            Optimizer optimizer;
-            try
-            {
-                optimizer = Optimizer.Get();
-            }
-            catch (DiiNotInitializedException ex)
-            {
-                _ = Optimizer.Init(typeof(FakeEntityTwo));
-                TestHelpers.AssertOptimizerIsInitialized();
-                optimizer = Optimizer.Get();
-            }
+            var optimizer = Optimizer.Get();
 
             var fakeEntityTwo = new FakeEntityTwo
             {

--- a/dii.storage.tests/OptimizerTests/ToEntityObjectTests.cs
+++ b/dii.storage.tests/OptimizerTests/ToEntityObjectTests.cs
@@ -12,16 +12,14 @@ namespace dii.storage.tests.OptimizerTests
     [TestCaseOrderer(TestPriorityOrderer.FullName, TestPriorityOrderer.AssemblyName)]
     public class ToEntityObjectTests
     {
-        [Fact, TestPriorityOrder(100)]
-        public void ToEntityObject_Prep()
+        public ToEntityObjectTests()
         {
             _ = Optimizer.Init(typeof(FakeEntityThree));
 
             TestHelpers.AssertOptimizerIsInitialized();
         }
 
-        
-        [Fact, TestPriorityOrder(104)]
+        [Fact, TestPriorityOrder(100)]
         public void ToEntityObject_UnregisteredType()
         {
             var optimizer = Optimizer.Get();
@@ -37,7 +35,7 @@ namespace dii.storage.tests.OptimizerTests
             Assert.Null(entity);
         }
 
-        [Fact, TestPriorityOrder(105)]
+        [Fact, TestPriorityOrder(101)]
         public void ToEntityObject_Null()
         {
             var optimizer = Optimizer.Get();

--- a/dii.storage.tests/OptimizerTests/ToEntityTests.cs
+++ b/dii.storage.tests/OptimizerTests/ToEntityTests.cs
@@ -12,15 +12,14 @@ namespace dii.storage.tests.OptimizerTests
     [TestCaseOrderer(TestPriorityOrderer.FullName, TestPriorityOrderer.AssemblyName)]
     public class ToEntityTests
     {
-        [Fact, TestPriorityOrder(100)]
-        public void ToEntity_Prep()
+        public ToEntityTests()
         {
             _ = Optimizer.Init(typeof(FakeEntityTwo), typeof(FakeEntityFive));
 
             TestHelpers.AssertOptimizerIsInitialized();
         }
 
-        [Fact, TestPriorityOrder(101)]
+        [Fact, TestPriorityOrder(100)]
         public void ToEntity_Success()
         {
             var optimizer = Optimizer.Get();
@@ -40,7 +39,7 @@ namespace dii.storage.tests.OptimizerTests
             Assert.Equal("kdkkZmFrZUVudGl0eVR3bzogQ29tcHJlc3NlZFN0cmluZ1ZhbHVl", entity.p);
         }
 
-        [Fact, TestPriorityOrder(102)]
+        [Fact, TestPriorityOrder(101)]
         public void ToEntity_SuccessWithSameIdAndPKProperty()
         {
             var optimizer = Optimizer.Get();
@@ -61,7 +60,7 @@ namespace dii.storage.tests.OptimizerTests
             Assert.Equal("kdklZmFrZUVudGl0eUZpdmU6IENvbXByZXNzZWRTdHJpbmdWYWx1ZQ==", entity.p);
         }
 
-        [Fact, TestPriorityOrder(103)]
+        [Fact, TestPriorityOrder(102)]
         public void ToEntity_UnregisteredType()
         {
             var optimizer = Optimizer.Get();
@@ -77,7 +76,7 @@ namespace dii.storage.tests.OptimizerTests
             Assert.Null(entity);
         }
 
-        [Fact, TestPriorityOrder(104)]
+        [Fact, TestPriorityOrder(103)]
         public void ToEntity_Null()
         {
             var optimizer = Optimizer.Get();

--- a/dii.storage.tests/OptimizerTests/UnpackageFromJsonTests.cs
+++ b/dii.storage.tests/OptimizerTests/UnpackageFromJsonTests.cs
@@ -13,18 +13,18 @@ namespace dii.storage.tests.OptimizerTests
     [TestCaseOrderer(TestPriorityOrderer.FullName, TestPriorityOrderer.AssemblyName)]
     public class UnpackageFromJsonTests
     {
-        [Fact, TestPriorityOrder(100)]
-        public void UnpackageFromJson_Prep()
+        public UnpackageFromJsonTests()
         {
             _ = Optimizer.Init(typeof(FakeEntityTwo));
 
             TestHelpers.AssertOptimizerIsInitialized();
         }
 
-        [Fact, TestPriorityOrder(101)]
+        [Fact, TestPriorityOrder(100)]
         public void UnpackageFromJson_Success()
         {
             var optimizer = Optimizer.Get();
+
             var id = Guid.NewGuid().ToString();
 
             var fakeEntityTwoJson = $"{{\"id\":\"{id}\",\"_etag\":null,\"p\":\"kdkkZmFrZUVudGl0eVR3bzogQ29tcHJlc3NlZFN0cmluZ1ZhbHVl\",\"PK\":\"{id}\"}}";
@@ -37,7 +37,7 @@ namespace dii.storage.tests.OptimizerTests
             Assert.Equal("fakeEntityTwo: CompressedStringValue", entity.CompressedStringValue);
         }
 
-        [Theory, TestPriorityOrder(102), ClassData(typeof(UnpackageFromJsonReturnDefaultData))]
+        [Theory, TestPriorityOrder(101), ClassData(typeof(UnpackageFromJsonReturnDefaultData))]
         public void UnpackageFromJson_UnregisteredType(string json)
         {
             var optimizer = Optimizer.Get();
@@ -47,7 +47,7 @@ namespace dii.storage.tests.OptimizerTests
             Assert.Equal(default, entity);
         }
 
-        [Theory, TestPriorityOrder(103), ClassData(typeof(UnpackageFromJsonExceptionData))]
+        [Theory, TestPriorityOrder(102), ClassData(typeof(UnpackageFromJsonExceptionData))]
         public void UnpackageFromJson_Exception(string json, Type exceptionType, string exceptionMessage)
         {
             var optimizer = Optimizer.Get();

--- a/dii.storage.tests/UtilityTests/IdHashUtilityTests.cs
+++ b/dii.storage.tests/UtilityTests/IdHashUtilityTests.cs
@@ -12,12 +12,7 @@ namespace dii.storage.tests.UtilityTests
     [TestCaseOrderer(TestPriorityOrderer.FullName, TestPriorityOrderer.AssemblyName)]
     public class IdHashUtilityTests
     {
-        //[Fact, TestPriorityOrder(100)]
-        //public void IdHashUtilityTests_Prep()
-        //{
-        //}
-
-        [Theory, TestPriorityOrder(101), ClassData(typeof(ValidateIdHashData))]
+        [Theory, TestPriorityOrder(100), ClassData(typeof(ValidateIdHashData))]
         public void IdHashUtilityTests_ValidateIdHash(string idHash, bool expectedOutcome)
         {
             var result = IdHashUtility.ValidateIdHash(idHash);
@@ -32,7 +27,7 @@ namespace dii.storage.tests.UtilityTests
             }
         }
 
-        [Fact, TestPriorityOrder(102)]
+        [Fact, TestPriorityOrder(101)]
         public void IdHashUtilityTests_NewId()
         {
             var id = IdHashUtility.NewId();
@@ -40,7 +35,7 @@ namespace dii.storage.tests.UtilityTests
             Assert.NotNull(id);
         }
 
-        [Theory, TestPriorityOrder(103), ClassData(typeof(ToIdHashData))]
+        [Theory, TestPriorityOrder(102), ClassData(typeof(ToIdHashData))]
         public void IdHashUtilityTests_ToIdHash(object value)
         {
             string id;
@@ -71,7 +66,7 @@ namespace dii.storage.tests.UtilityTests
             Assert.Equal("gBNEpi.Y2Qg", id);
         }
 
-        [Theory, TestPriorityOrder(104), ClassData(typeof(ToIdHashData))]
+        [Theory, TestPriorityOrder(103), ClassData(typeof(ToIdHashData))]
         public void IdHashUtilityTests_AsIdHash(object value)
         {
             string id;
@@ -101,12 +96,5 @@ namespace dii.storage.tests.UtilityTests
 
             Assert.Equal("gBNEpi.Y2Qg", id);
         }
-
-        #region Teardown
-        //[Fact, TestPriorityOrder(int.MaxValue)]
-        //public void Teardown()
-        //{
-        //}
-        #endregion
     }
 }

--- a/dii.storage/OptimizedTypeRegistrar.cs
+++ b/dii.storage/OptimizedTypeRegistrar.cs
@@ -93,7 +93,7 @@ namespace dii.storage
 		/// </param>
 		public static void ClearAllTypes(bool iUnderstandThisShouldOnlyBeUsedForTesting)
 		{
-			if(iUnderstandThisShouldOnlyBeUsedForTesting)
+			if (iUnderstandThisShouldOnlyBeUsedForTesting)
 			{
 				_packing.Clear();
 				_unpacking.Clear();


### PR DESCRIPTION
Removed most of the prep tests which inflated the test count. Removed unused test placeholders and reset test order counts to match.