### PR TITLE
Add overload for Partition Keys as an object

### DIFF
--- a/dii.storage.cosmos.tests/Adapters/FakeHPKEntityAdapter.cs
+++ b/dii.storage.cosmos.tests/Adapters/FakeHPKEntityAdapter.cs
@@ -2,10 +2,7 @@
 using dii.storage.cosmos.tests.Models;
 using dii.storage.cosmos.tests.Models.Interfaces;
 using Microsoft.Azure.Cosmos;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -14,6 +11,11 @@ namespace dii.storage.cosmos.tests.Adapters
     public class FakeHPKEntityAdapter : DiiCosmosHierarchicalAdapter<FakeHPKEntity>, IFakeHierarchicalAdapter<FakeHPKEntity>
     {
         Task<FakeHPKEntity> IFakeHierarchicalAdapter<FakeHPKEntity>.GetAsync(string id, Dictionary<string, string> partitionKeys, ItemRequestOptions requestOptions, CancellationToken cancellationToken)
+        {
+            return base.GetAsync(id, partitionKeys, requestOptions, cancellationToken);
+        }
+
+        Task<FakeHPKEntity> IFakeHierarchicalAdapter<FakeHPKEntity>.GetAsync(string id, Dictionary<string, object> partitionKeys, ItemRequestOptions requestOptions, CancellationToken cancellationToken)
         {
             return base.GetAsync(id, partitionKeys, requestOptions, cancellationToken);
         }
@@ -64,6 +66,11 @@ namespace dii.storage.cosmos.tests.Adapters
         }
 
         Task<FakeHPKEntity> IFakeHierarchicalAdapter<FakeHPKEntity>.PatchAsync(string id, Dictionary<string, string> partitionKeys, Dictionary<string, object> patchOperations, PatchItemRequestOptions requestOptions, CancellationToken cancellationToken)
+        {
+            return base.PatchAsync(id, partitionKeys, patchOperations, requestOptions, cancellationToken);
+        }
+
+        Task<FakeHPKEntity> IFakeHierarchicalAdapter<FakeHPKEntity>.PatchAsync(string id, Dictionary<string, object> partitionKeys, Dictionary<string, object> patchOperations, PatchItemRequestOptions requestOptions, CancellationToken cancellationToken)
         {
             return base.PatchAsync(id, partitionKeys, patchOperations, requestOptions, cancellationToken);
         }

--- a/dii.storage.cosmos.tests/Models/Interfaces/IFakeHierarchicalAdapter.cs
+++ b/dii.storage.cosmos.tests/Models/Interfaces/IFakeHierarchicalAdapter.cs
@@ -1,10 +1,7 @@
 ﻿using dii.storage.cosmos.Models;
 using dii.storage.Models.Interfaces;
 using Microsoft.Azure.Cosmos;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -13,6 +10,7 @@ namespace dii.storage.cosmos.tests.Models.Interfaces
     public interface IFakeHierarchicalAdapter<T> where T : IDiiEntity, new()
     {
         Task<T> GetAsync(string id, Dictionary<string, string> partitionKeys, ItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default);
+        Task<T> GetAsync(string id, Dictionary<string, object> partitionKeys, ItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default);
         Task<PagedList<T>> GetManyAsync(IReadOnlyList<(string id, Dictionary<string, string> partitionKeys)> idAndPks, QueryRequestOptions readManyRequestOptions = null, CancellationToken cancellationToken = default);
         Task<PagedList<T>> GetPagedAsync(QueryDefinition queryDefinition, string continuationToken = null, QueryRequestOptions requestOptions = null);
         Task<PagedList<T>> GetPagedAsync(string queryText = null, string continuationToken = null, QueryRequestOptions requestOptions = null);
@@ -23,11 +21,11 @@ namespace dii.storage.cosmos.tests.Models.Interfaces
         Task<T> UpsertAsync(T diiEntity, ItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default);
         Task<List<T>> UpsertBulkAsync(IReadOnlyList<T> diiEntities, ItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default);
         Task<T> PatchAsync(string id, Dictionary<string, string> partitionKeys, Dictionary<string, object> patchOperations, PatchItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default);
+        Task<T> PatchAsync(string id, Dictionary<string, object> partitionKeys, Dictionary<string, object> patchOperations, PatchItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default);
         Task<List<T>> PatchBulkAsync(IReadOnlyList<(string id, Dictionary<string, string> partitionKeys, Dictionary<string, object> listOfPatchOperations)> patchOperations, PatchItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default);
         Task<bool> DeleteEntityAsync(T diiEntity, ItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default);
         Task<bool> DeleteAsync(string id, Dictionary<string, string> partitionKeys, ItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default);
         Task<bool> DeleteEntitiesBulkAsync(IReadOnlyList<T> diiEntities, ItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default);
         Task<bool> DeleteBulkAsync(IReadOnlyList<(string id, Dictionary<string, string> partitionKeys)> idAndPks, ItemRequestOptions requestOptions = null, CancellationToken cancellationToken = default);
     }
-
 }

--- a/dii.storage.cosmos/dii.storage.cosmos.csproj
+++ b/dii.storage.cosmos/dii.storage.cosmos.csproj
@@ -11,7 +11,7 @@
     <Authors>Andrew Beers, Pat MacMannis &amp; Derek Jeremias</Authors>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageId>dii.storage.cosmos</PackageId>
-    <Version>2.0.5</Version>
+    <Version>2.1.0</Version>
     <AssemblyName>dii.storage.cosmos</AssemblyName>
     <RootNamespace>dii.storage.cosmos</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/dii.storage/dii.storage.csproj
+++ b/dii.storage/dii.storage.csproj
@@ -11,7 +11,7 @@
     <Authors>Andrew Beers, Pat MacMannis &amp; Derek Jeremias</Authors>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageId>dii.storage</PackageId>
-    <Version>2.0.5</Version>
+    <Version>2.1.0</Version>
     <AssemblyName>dii.storage</AssemblyName>
     <RootNamespace>dii.storage</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
The current version `2.0.5` only allows multiple partition keys as `string`.
`Microsoft.Azure.Cosmos.PartitionKeyBuilder` allows `double`, `string` & `bool`.

With this PR we're adding new overloads to let the consumer use any of those types.

Nuget Version bump to `2.1.0`